### PR TITLE
fix(readBuffer): handle 0-byte reads

### DIFF
--- a/src/readBuffer.js
+++ b/src/readBuffer.js
@@ -1,4 +1,8 @@
 export default function readBuffer(pipe, length, callback) {
+  if (length === 0) {
+    callback(null, new Buffer(0));
+    return;
+  }
   let remainingLength = length;
   const buffers = [];
   const readChunk = () => {


### PR DESCRIPTION
without this onChunk will infinitely wait for data

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
