### PR TITLE
docs(README): fix `workerNodeArgs` arguments in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ use: [
       workerParallelJobs: 50,
 
       // additional node.js arguments
-      workerNodeArgs: ['--max-old-space-size', '1024'],
+      workerNodeArgs: ['--max-old-space-size=1024'],
 
       // timeout for killing the worker processes when idle
       // defaults to 500 (ms)


### PR DESCRIPTION
- Error: missing value for flag --max-old-space-size of type int

When the option written in the README is specified, the above error occurs and it was corrected.
