### PR TITLE
fix(cjs): enable `webpack =< v1.0.0` support

### DIFF
--- a/src/cjs.js
+++ b/src/cjs.js
@@ -1,1 +1,6 @@
-module.exports = require('./index');
+function threadLoader() {
+  throw new Error('This function should never be invoked');
+}
+Object.assign(threadLoader, require('./index'));
+
+module.exports = threadLoader;


### PR DESCRIPTION
### `Issues`

- Fixes #17 

### `Notable Changes`

Exported loader is now a `{Function}`, to satisfy `webpack` 1's runtime typecheck.
