### PR TITLE
fix(WorkerError): handle undefined `error` stacks

### DIFF
--- a/src/WorkerError.js
+++ b/src/WorkerError.js
@@ -1,5 +1,5 @@
 const stack = (err, worker, workerId) => {
-  const originError = err.stack
+  const originError = (err.stack || '')
     .split('\n')
     .filter(line => line.trim().startsWith('at'));
 


### PR DESCRIPTION
### `Issues`

- Fixes #19 

### `Notable Changes`

Before this change, an error reported without a stack would crash the process:
![image](https://user-images.githubusercontent.com/6445614/36639309-d814f010-19be-11e8-8354-af082e38a23d.png)

After this change, the error is properly reported:
![image](https://user-images.githubusercontent.com/6445614/36639301-adc495ea-19be-11e8-8637-3f3c108aa382.png)
