### PR TITLE
Drop support for node < 6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,7 @@
       {
         "useBuiltIns": true,
         "targets": {
-          "node": "4.8"
+          "node": "6.9.0"
         },
         "exclude": [
           "transform-async-to-generator",

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@ jobs:
       env: WEBPACK_VERSION=latest JOB_PART=test
       script: npm run travis:$JOB_PART
     - <<: *test-latest
-      node_js: 4.8
-      env: WEBPACK_VERSION=latest JOB_PART=test
-      script: npm run travis:$JOB_PART
-    - <<: *test-latest
       node_js: 8
       env: WEBPACK_VERSION=latest JOB_PART=lint
       script: npm run travis:$JOB_PART

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,6 @@ environment:
     - nodejs_version: '6'
       webpack_version: latest
       job_part: test
-    - nodejs_version: '4.8'
-      webpack_version: latest
-      job_part: test
 build: 'off'
 matrix:
   fast_finish: true

--- a/example/.babelrc
+++ b/example/.babelrc
@@ -5,7 +5,7 @@
       {
         "useBuiltIns": true,
         "targets": {
-          "node": 4.3
+          "node": "6.9.0"
         },
         "exclude": [
           "transform-async-to-generator",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "webpack-defaults": "^1.6.0"
   },
   "engines": {
-    "node": ">= 4.8 < 5.0.0 || >= 5.10"
+    "node": ">= 6.9.0 <7.0.0 || >= 8.9.0"
   },
   "peerDependencies": {
     "webpack": "^2.0.0 || ^3.0.0 || ^4.0.0"


### PR DESCRIPTION
Other loaders @1.x on webpack (like `css-loader` for example) don't support a node version `< 6.9.0`. 
We should do the same as the other lower node versions are really old and not updated anymore with security patches (end of life for 4.x was April 2018).

This PR drops the support node versions < 6.9.0.

\CC @evilebottnawi 