### PR TITLE
Proper function to calculate number of workers correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ use: [
     loader: "thread-loader",
     // loaders with equal options will share worker pools
     options: {
-      // the number of spawned workers, defaults to number of cpus
+      // the number of spawned workers, defaults to (number of cpus - 1) or
+      // fallback to 1 when require('os').cpus() is undefined
       workers: 2,
 
       // number of jobs a worker processes in parallel

--- a/src/workerPools.js
+++ b/src/workerPools.js
@@ -3,10 +3,23 @@ import WorkerPool from './WorkerPool';
 
 const workerPools = Object.create(null);
 
+function calculateNumberOfWorkers() {
+  const cpus = os.cpus();
+
+  if (!cpus) {
+    // There are situations when this call will return undefined so
+    // we are fallback here to 1.
+    // More info on: https://github.com/nodejs/node/issues/19022
+    return 1;
+  }
+
+  return Math.max(1, cpus.length - 1);
+}
+
 function getPool(options) {
   const workerPoolOptions = {
     name: options.name || '',
-    numberOfWorkers: options.workers || os.cpus().length,
+    numberOfWorkers: options.workers || calculateNumberOfWorkers(),
     workerNodeArgs: options.workerNodeArgs,
     workerParallelJobs: options.workerParallelJobs || 20,
     poolTimeout: options.poolTimeout || 500,


### PR DESCRIPTION
There are some situations when `require('os').cpus()` will return `undefined` (https://github.com/nodejs/node/issues/19022).

This PR introduces a function to correctly calculate the number of workers or fallback it to 1 when it is not able to determine the correct number.

\CC @evilebottnawi 