### PR TITLE
Fix thread-loader memory leaks and worker and main process lifecycles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4205,6 +4205,14 @@
         "null-check": "^1.0.0"
       }
     },
+    "fs-minipass": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+      "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
+      "requires": {
+        "minipass": "^2.2.1"
+      }
+    },
     "fs-readdir-recursive": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz",
@@ -4492,6 +4500,9 @@
           "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
           "requires": {
             "chownr": "^1.0.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.2.4",
+            "minizlib": "^1.1.0",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.2"
@@ -8037,6 +8048,35 @@
         "is-plain-obj": "^1.1.0"
       }
     },
+    "minipass": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+      "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+      "requires": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+        }
+      }
+    },
+    "minizlib": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+      "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
+      "requires": {
+        "minipass": "^2.2.1"
+      }
+    },
     "mississippi": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
@@ -8362,11 +8402,56 @@
         "detect-libc": "^1.0.2",
         "mkdirp": "^0.5.1",
         "needle": "^2.2.0",
+        "nopt": "^4.0.1",
         "npm-packlist": "^1.1.6",
         "npmlog": "^4.0.2",
         "rc": "^1.1.7",
         "rimraf": "^2.6.1",
-        "semver": "^5.3.0"
+        "semver": "^5.3.0",
+        "tar": "^4"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.8",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+          "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "node-sass": {
@@ -9766,6 +9851,7 @@
       "dev": true,
       "requires": {
         "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
         "math-random": "^1.0.1"
       },
       "dependencies": {
@@ -9773,6 +9859,12 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
           "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
       }

--- a/src/WorkerPool.js
+++ b/src/WorkerPool.js
@@ -42,13 +42,23 @@ class PoolWorker {
   }
 
   listenStdOutAndErrFromWorker(workerStdout, workerStderr) {
-    workerStdout.on('data', this.writeToStdout);
-    workerStderr.on('data', this.writeToStderr);
+    if (workerStdout) {
+      workerStdout.on('data', this.writeToStdout);
+    }
+
+    if (workerStderr) {
+      workerStderr.on('data', this.writeToStderr);
+    }
   }
 
   ignoreStdOutAndErrFromWorker(workerStdout, workerStderr) {
-    workerStdout.removeListener('data', this.writeToStdout);
-    workerStderr.removeListener('data', this.writeToStderr);
+    if (workerStdout) {
+      workerStdout.removeListener('data', this.writeToStdout);
+    }
+
+    if (workerStderr) {
+      workerStderr.removeListener('data', this.writeToStderr);
+    }
   }
 
   writeToStdout(data) {

--- a/src/readBuffer.js
+++ b/src/readBuffer.js
@@ -4,16 +4,11 @@ export default function readBuffer(pipe, length, callback) {
     return;
   }
 
-  let terminated = false;
   let remainingLength = length;
   const buffers = [];
 
   const readChunk = () => {
     const onChunk = (arg) => {
-      if (terminated) {
-        return;
-      }
-
       let chunk = arg;
       let overflow;
       if (chunk.length > remainingLength) {
@@ -36,20 +31,6 @@ export default function readBuffer(pipe, length, callback) {
       }
     };
 
-    const onTerminate = () => {
-      if (terminated) {
-        return;
-      }
-
-      terminated = true;
-      pipe.removeListener('close', onTerminate);
-      pipe.removeListener('end', onTerminate);
-
-      callback(null, Buffer.alloc(0));
-    };
-
-    pipe.on('close', onTerminate);
-    pipe.on('end', onTerminate);
     pipe.on('data', onChunk);
     pipe.resume();
   };

--- a/src/readBuffer.js
+++ b/src/readBuffer.js
@@ -1,16 +1,19 @@
 export default function readBuffer(pipe, length, callback) {
   if (length === 0) {
-    callback(null, new Buffer(0));
+    callback(null, Buffer.alloc(0));
     return;
   }
+
   let terminated = false;
   let remainingLength = length;
   const buffers = [];
+
   const readChunk = () => {
     const onChunk = (arg) => {
       if (terminated) {
         return;
       }
+
       let chunk = arg;
       let overflow;
       if (chunk.length > remainingLength) {
@@ -22,26 +25,32 @@ export default function readBuffer(pipe, length, callback) {
       }
       buffers.push(chunk);
       if (remainingLength === 0) {
-        pipe.pause();
         pipe.removeListener('data', onChunk);
+        pipe.pause();
+
         if (overflow) {
           pipe.unshift(overflow);
         }
-        terminated = true;
+
         callback(null, Buffer.concat(buffers, length));
       }
     };
-    const onEnd = () => {
+
+    const onTerminate = () => {
       if (terminated) {
         return;
       }
+
       terminated = true;
-      const err = new Error(`Stream ended ${remainingLength.toString()} bytes prematurely`);
-      err.name = 'EarlyEOFError';
-      callback(err);
+      pipe.removeListener('close', onTerminate);
+      pipe.removeListener('end', onTerminate);
+
+      callback(null, Buffer.alloc(0));
     };
+
+    pipe.on('close', onTerminate);
+    pipe.on('end', onTerminate);
     pipe.on('data', onChunk);
-    pipe.on('end', onEnd);
     pipe.resume();
   };
   readChunk();

--- a/src/worker.js
+++ b/src/worker.js
@@ -92,8 +92,8 @@ function writeJson(data) {
     writePipeUncork();
   });
 
-  const lengthBuffer = new Buffer(4);
-  const messageBuffer = new Buffer(JSON.stringify(data), 'utf-8');
+  const lengthBuffer = Buffer.alloc(4);
+  const messageBuffer = Buffer.from(JSON.stringify(data), 'utf-8');
   lengthBuffer.writeInt32BE(messageBuffer.length, 0);
 
   writePipeWrite(lengthBuffer);

--- a/test/readBuffer.test.js
+++ b/test/readBuffer.test.js
@@ -25,7 +25,7 @@ test('data is read', (done) => {
 });
 
 test('no data is read when early quit but no error is thrown', (done) => {
-  expect.assertions(2);
+  expect.assertions(1);
   let eventCount = 0;
   function read() {
     eventCount += 1;
@@ -38,10 +38,10 @@ test('no data is read when early quit but no error is thrown', (done) => {
     objectMode: true,
     read,
   });
-  function cb(err, data) {
-    expect(err).toBe(null);
-    expect(data.length).toBe(0);
-    done();
-  }
+
+  const cb = jest.fn();
   readBuffer.default(mockEventStream, 8, cb);
+
+  expect(cb).not.toHaveBeenCalled();
+  done();
 });

--- a/test/readBuffer.test.js
+++ b/test/readBuffer.test.js
@@ -24,7 +24,7 @@ test('data is read', (done) => {
   readBuffer.default(mockEventStream, 8, cb);
 });
 
-test('EOF returned for early quit', (done) => {
+test('no data is read when early quit but no error is thrown', (done) => {
   expect.assertions(2);
   let eventCount = 0;
   function read() {
@@ -38,9 +38,9 @@ test('EOF returned for early quit', (done) => {
     objectMode: true,
     read,
   });
-  function cb(err) {
-    expect(err.name).toBe('EarlyEOFError');
-    expect(err.message).toBe('Stream ended 3 bytes prematurely');
+  function cb(err, data) {
+    expect(err).toBe(null);
+    expect(data.length).toBe(0);
     done();
   }
   readBuffer.default(mockEventStream, 8, cb);

--- a/test/workerPool.test.js
+++ b/test/workerPool.test.js
@@ -5,15 +5,15 @@ import WorkerPool from '../src/WorkerPool';
 jest.mock('child_process', () => {
   return {
     spawn: jest.fn(() => {
-      return {};
+      return {
+        unref: jest.fn(),
+      };
     }),
   };
 });
 
 describe('workerPool', () => {
   it('should throw an error when worker.stdio is undefined', () => {
-    childProcess.spawn.mockImplementationOnce(() => { return {}; });
-
     const workerPool = new WorkerPool({});
     expect(() => workerPool.createWorker()).toThrowErrorMatchingSnapshot();
     expect(() => workerPool.createWorker()).toThrowError('Please verify if you hit the OS open files limit');
@@ -23,6 +23,7 @@ describe('workerPool', () => {
     childProcess.spawn.mockImplementationOnce(() => {
       return {
         stdio: new Array(5).fill(new stream.PassThrough()),
+        unref: jest.fn(),
       };
     });
 


### PR DESCRIPTION
This PR is very important and should be merged and released as a patch as soon as possible. 
It basically fixes a memory leak introduced by https://github.com/webpack-contrib/thread-loader/pull/42 and also fixes the lifecycle both for the worker and for the main process from `thread-loader`. With those changes we should be able to get away with every issue related with getting the `thread-loader hanging` or outputting `broken pipe` errors directly into the shell stdout after running.

The tests were also updated. 

CC\ @evilebottnawi  