### PR TITLE
feat: Add `poolRespawn` option to speed up incremental builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ use: [
       // additional node.js arguments
       workerNodeArgs: ['--max-old-space-size=1024'],
 
+      // Allow to respawn a dead worker pool
+      // respawning slows down the entire compilation
+      // and should be set to false for development
+      poolRespawn: false,
+
       // timeout for killing the worker processes when idle
       // defaults to 500 (ms)
       // can be set to Infinity for watching builds to keep workers alive

--- a/src/WorkerPool.js
+++ b/src/WorkerPool.js
@@ -263,6 +263,10 @@ export default class WorkerPool {
     this.setupLifeCycle();
   }
 
+  isAbleToRun() {
+    return !this.terminated;
+  }
+
   terminate(force) {
     if (!this.terminated) {
       this.terminated = true;
@@ -340,6 +344,9 @@ export default class WorkerPool {
         worker.dispose();
       }
       this.workers.clear();
+    }
+    if (!this.options.poolRespawn) {
+      this.terminate();
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,9 @@ import { getPool } from './workerPools';
 function pitch() {
   const options = loaderUtils.getOptions(this) || {};
   const workerPool = getPool(options);
+  if (!workerPool.isAbleToRun()) {
+    return;
+  }
   const callback = this.async();
   workerPool.run({
     loaders: this.loaders.slice(this.loaderIndex + 1).map((l) => {

--- a/src/workerPools.js
+++ b/src/workerPools.js
@@ -20,6 +20,7 @@ function getPool(options) {
     workerParallelJobs: options.workerParallelJobs || 20,
     poolTimeout: options.poolTimeout || 500,
     poolParallelJobs: options.poolParallelJobs || 200,
+    poolRespawn: options.poolRespawn || false,
   };
   const tpKey = JSON.stringify(workerPoolOptions);
   workerPools[tpKey] = workerPools[tpKey] || new WorkerPool(workerPoolOptions);

--- a/test/pitch.test.js
+++ b/test/pitch.test.js
@@ -11,6 +11,7 @@ jest.mock('../src/workerPools', () => {
 const runGetPoolMock = (error) => {
   getPool.mockImplementationOnce(() => {
     return {
+      isAbleToRun: () => true,
       run: jest.fn((opts, cb) => {
         cb(error, {
           fileDependencies: [],

--- a/test/workerPool.test.js
+++ b/test/workerPool.test.js
@@ -30,4 +30,15 @@ describe('workerPool', () => {
     const workerPool = new WorkerPool({});
     expect(() => workerPool.createWorker()).not.toThrow();
   });
+
+  it('should be able to run if the worker pool was not terminated', () => {
+    const workerPool = new WorkerPool({});
+    expect(workerPool.isAbleToRun()).toBe(true);
+  });
+
+  it('should not be able to run if the worker pool was not terminated', () => {
+    const workerPool = new WorkerPool({});
+    workerPool.terminate();
+    expect(workerPool.isAbleToRun()).toBe(false);
+  });
 });


### PR DESCRIPTION
<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->

The thread-loader [doubled the build duration for incremental builds](
https://github.com/namics/webpack-config-plugins/issues/24#issuecomment-448297256) because of the WorkerPool which is disposed after 500ms by default.

This pr tries adds `poolRespawn:false` to solve this problem similar to `poolTimeout: Infinity`.  If set to `false` it will not respawn a worker pool once it was disposed.

So unlike `poolTimeout: Infinity` this feature allows to use the thread-loader only for the initial build.  
The idea behind that is that the initial startup has to transpile all files but incremental builds usually transpile only a single file.

As this would have no negative impact for a production webpack-cli build we might even set`poolRespawn:false` as default.  
Please let me know if that would be okay for you so I can adjust this pr.