### PR TITLE
Use neo-async insteaf of async

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -634,6 +634,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "dev": true,
       "requires": {
         "lodash": "^4.17.10"
       }
@@ -7614,7 +7615,8 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -8270,8 +8272,7 @@
     "neo-async": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
-      "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
-      "dev": true
+      "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA=="
     },
     "nested-error-stacks": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "webpack-defaults": "webpack-defaults"
   },
   "dependencies": {
-    "async": "^2.6.1",
+    "neo-async": "^2.6.0",
     "loader-runner": "^2.3.1",
     "loader-utils": "^1.1.0"
   },

--- a/src/WorkerPool.js
+++ b/src/WorkerPool.js
@@ -1,8 +1,8 @@
 /* eslint-disable no-console */
 
 import childProcess from 'child_process';
-import asyncQueue from 'async/queue';
-import asyncMapSeries from 'async/mapSeries';
+import asyncQueue from 'neo-async/queue';
+import asyncMapSeries from 'neo-async/mapSeries';
 import readBuffer from './readBuffer';
 import WorkerError from './WorkerError';
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -3,7 +3,7 @@
 import fs from 'fs';
 import NativeModule from 'module';
 import loaderRunner from 'loader-runner';
-import asyncQueue from 'async/queue';
+import asyncQueue from 'neo-async/queue';
 import readBuffer from './readBuffer';
 
 const writePipe = fs.createWriteStream(null, { fd: 3 });


### PR DESCRIPTION
This PR replaces `async` with `neo-async` and improves the `thread-loader` performance a lot!

\CC @evilebottnawi 