### PR TITLE
Fix lifecycle handling for signals

### DIFF
--- a/src/WorkerPool.js
+++ b/src/WorkerPool.js
@@ -267,26 +267,30 @@ export default class WorkerPool {
     return !this.terminated;
   }
 
-  terminate(force) {
-    if (!this.terminated) {
+  terminate({ exit, clean }) {
+    if (exit) {
       this.terminated = true;
+      process.exit(0);
+      return;
+    }
 
+    if (clean) {
       this.poolQueue.kill();
-      this.disposeWorkers(force);
+      this.disposeWorkers(true);
     }
   }
 
   setupLifeCycle() {
     process.on('SIGTERM', () => {
-      this.terminate(true);
+      this.terminate({ exit: true });
     });
 
     process.on('SIGINT', () => {
-      this.terminate(true);
+      this.terminate({ exit: true });
     });
 
     process.on('exit', () => {
-      this.terminate(true);
+      this.terminate({ clean: true });
     });
   }
 

--- a/src/WorkerPool.js
+++ b/src/WorkerPool.js
@@ -278,6 +278,14 @@ export default class WorkerPool {
   }
 
   setupLifeCycle() {
+    process.on('SIGTERM', () => {
+      process.exit(1);
+    });
+
+    process.on('SIGINT', () => {
+      process.exit(1);
+    });
+
     process.on('exit', () => {
       this.terminate();
     });
@@ -333,7 +341,7 @@ export default class WorkerPool {
 
   disposeWorkers(fromTerminate) {
     if (!this.options.poolRespawn && !fromTerminate) {
-      this.terminate({ exit: true });
+      this.terminate();
       return;
     }
 

--- a/src/WorkerPool.js
+++ b/src/WorkerPool.js
@@ -258,18 +258,18 @@ export default class WorkerPool {
     this.activeJobs = 0;
     this.timeout = null;
     this.poolQueue = asyncQueue(this.distributeJob.bind(this), options.poolParallelJobs);
-    this.terminated = false;
+    this.exited = false;
 
     this.setupLifeCycle();
   }
 
   isAbleToRun() {
-    return !this.terminated;
+    return !this.exited;
   }
 
   terminate({ exit, clean }) {
     if (exit) {
-      this.terminated = true;
+      this.exited = true;
       process.exit(0);
       return;
     }

--- a/src/WorkerPool.js
+++ b/src/WorkerPool.js
@@ -342,15 +342,17 @@ export default class WorkerPool {
     }
   }
 
-  disposeWorkers(force) {
-    if (this.activeJobs === 0 || force) {
+  disposeWorkers(fromTerminate) {
+    if (!this.options.poolRespawn && !fromTerminate) {
+      this.terminate({ exit: true });
+      return;
+    }
+
+    if (this.activeJobs === 0 || fromTerminate) {
       for (const worker of this.workers) {
         worker.dispose();
       }
       this.workers.clear();
-    }
-    if (!this.options.poolRespawn) {
-      this.terminate();
     }
   }
 }

--- a/src/WorkerPool.js
+++ b/src/WorkerPool.js
@@ -278,14 +278,6 @@ export default class WorkerPool {
   }
 
   setupLifeCycle() {
-    process.on('SIGTERM', () => {
-      process.exit(1);
-    });
-
-    process.on('SIGINT', () => {
-      process.exit(1);
-    });
-
     process.on('exit', () => {
       this.terminate();
     });

--- a/src/WorkerPool.js
+++ b/src/WorkerPool.js
@@ -258,39 +258,28 @@ export default class WorkerPool {
     this.activeJobs = 0;
     this.timeout = null;
     this.poolQueue = asyncQueue(this.distributeJob.bind(this), options.poolParallelJobs);
-    this.exited = false;
+    this.terminated = false;
 
     this.setupLifeCycle();
   }
 
   isAbleToRun() {
-    return !this.exited;
+    return !this.terminated;
   }
 
-  terminate({ exit, clean }) {
-    if (exit) {
-      this.exited = true;
-      process.exit(0);
+  terminate() {
+    if (this.terminated) {
       return;
     }
 
-    if (clean) {
-      this.poolQueue.kill();
-      this.disposeWorkers(true);
-    }
+    this.terminated = true;
+    this.poolQueue.kill();
+    this.disposeWorkers(true);
   }
 
   setupLifeCycle() {
-    process.on('SIGTERM', () => {
-      this.terminate({ exit: true });
-    });
-
-    process.on('SIGINT', () => {
-      this.terminate({ exit: true });
-    });
-
     process.on('exit', () => {
-      this.terminate({ clean: true });
+      this.terminate();
     });
   }
 

--- a/test/workerPool.test.js
+++ b/test/workerPool.test.js
@@ -36,7 +36,7 @@ describe('workerPool', () => {
     expect(workerPool.isAbleToRun()).toBe(true);
   });
 
-  it('should not be able to run if the worker pool was not terminated', () => {
+  it('should not be able to run if the worker pool was terminated', () => {
     const workerPool = new WorkerPool({});
     workerPool.terminate();
     expect(workerPool.isAbleToRun()).toBe(false);


### PR DESCRIPTION
This PR solves a problem with handling signals on thread-loader process itself which was resulting on process hang in some situations (like for example using webpack-dev-server from a forked process).

Closes https://github.com/webpack-contrib/thread-loader/issues/56

\CC @evilebottnawi 