### PR TITLE
fix: do not allow empty or invalid node args when spin up child process

### DIFF
--- a/src/WorkerPool.js
+++ b/src/WorkerPool.js
@@ -252,7 +252,8 @@ export default class WorkerPool {
     this.options = options || {};
     this.numberOfWorkers = options.numberOfWorkers;
     this.poolTimeout = options.poolTimeout;
-    this.workerNodeArgs = options.workerNodeArgs;
+    // Empty or invalid node args would break the child process
+    this.workerNodeArgs = options.workerNodeArgs.filter(opt => !!opt);
     this.workerParallelJobs = options.workerParallelJobs;
     this.workers = new Set();
     this.activeJobs = 0;

--- a/src/WorkerPool.js
+++ b/src/WorkerPool.js
@@ -18,8 +18,12 @@ class PoolWorker {
     this.activeJobs = 0;
     this.onJobDone = onJobDone;
     this.id = workerId;
+
     workerId += 1;
-    this.worker = childProcess.spawn(process.execPath, [].concat(options.nodeArgs || []).concat(workerPath, options.parallelJobs), {
+    // Empty or invalid node args would break the child process
+    const sanitizedNodeArgs = (options.nodeArgs || []).filter(opt => !!opt);
+
+    this.worker = childProcess.spawn(process.execPath, [].concat(sanitizedNodeArgs).concat(workerPath, options.parallelJobs), {
       detached: true,
       stdio: ['ignore', 'pipe', 'pipe', 'pipe', 'pipe'],
     });
@@ -252,8 +256,7 @@ export default class WorkerPool {
     this.options = options || {};
     this.numberOfWorkers = options.numberOfWorkers;
     this.poolTimeout = options.poolTimeout;
-    // Empty or invalid node args would break the child process
-    this.workerNodeArgs = options.workerNodeArgs.filter(opt => !!opt);
+    this.workerNodeArgs = options.workerNodeArgs;
     this.workerParallelJobs = options.workerParallelJobs;
     this.workers = new Set();
     this.activeJobs = 0;


### PR DESCRIPTION
If we pass empty or invalid node args into thread-loader that would break and stop the child processes. That PR fixes it.

/CC @evilebottnawi 