### PR TITLE
Use correct default for worker parallel jobs

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -17,7 +17,7 @@ readPipe.on('close', onTerminateRead);
 readPipe.on('error', onError);
 writePipe.on('error', onError);
 
-const PARALLEL_JOBS = +process.argv[2];
+const PARALLEL_JOBS = +process.argv[2] || 20;
 
 let terminated = false;
 let nextQuestionId = 0;


### PR DESCRIPTION
It looks like the correct default for the workerParallelJobs option were not applied before. 
That PR should fix it.

/CC @evilebottnawi 