### PR TITLE
Extend loader context (to support less-loader)

### DIFF
--- a/src/WorkerPool.js
+++ b/src/WorkerPool.js
@@ -188,6 +188,29 @@ class PoolWorker {
         });
         break;
       }
+      case 'loadModule': {
+        const { request, questionId } = message;
+        const { data } = this.jobs[id];
+        data.loadModule(request, (error, source, sourceMap, module) => {
+          this.writeJson({
+            type: 'result',
+            id: questionId,
+            error: error ? {
+              message: error.message,
+              details: error.details,
+              missing: error.missing,
+            } : null,
+            result: [
+              source,
+              sourceMap,
+              // TODO: Serialize module?
+              // module,
+            ],
+          });
+        });
+        finalCallback();
+        break;
+      }
       case 'resolve': {
         const { context, request, questionId } = message;
         const { data } = this.jobs[id];

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ function pitch() {
     sourceMap: this.sourceMap,
     emitError: this.emitError,
     emitWarning: this.emitWarning,
+    loadModule: this.loadModule,
     resolve: this.resolve,
     target: this.target,
     minimize: this.minimize,

--- a/src/worker.js
+++ b/src/worker.js
@@ -107,6 +107,17 @@ const queue = asyncQueue(({ id, data }, taskCallback) => {
       readResource: fs.readFile.bind(fs),
       context: {
         version: 2,
+        fs,
+        loadModule: (request, callback) => {
+          callbackMap[nextQuestionId] = (error, result) => callback(error, ...result);
+          writeJson({
+            type: 'loadModule',
+            id,
+            questionId: nextQuestionId,
+            request,
+          });
+          nextQuestionId += 1;
+        },
         resolve: (context, request, callback) => {
           callbackMap[nextQuestionId] = callback;
           writeJson({


### PR DESCRIPTION
The less-loader package uses the `fs` and `loadModule` properties on the loader context, but those were not provided by this package. So this PR adds them in.

A few notes:
- The `fs` property is simply the imported NodeJS `fs` module. So if the user has configured a different filesystem using Webpack's `inputFileSystem` option this will not be forwarded into the workers. This might cause unexpected issues, but I don't directly see a nice way around this issue.
- The actual `loadModule` function returns (besides `source` and `sourceMap`, which are strings) the `module`, which is an instance of `NormalModule`. This class cannot be trivially serialized, so I pass `undefined` instead. Again, this might cause unexpected issues.

Additionally, it looks like future less-loader versions will use `getResolve` instead of `resolve` just like sass-loader. So it would probably be a good idea to add support for that as well.