### PR TITLE
fix(context): pass rootContext

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ function pitch() {
       minimize: this.minimize,
       resourceQuery: this.resourceQuery,
       optionsContext: this.rootContext || this.options.context,
+      rootContext: this.rootContext,
     },
     (err, r) => {
       if (r) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -187,6 +187,7 @@ const queue = asyncQueue(({ id, data }, taskCallback) => {
           target: data.target,
           minimize: data.minimize,
           resourceQuery: data.resourceQuery,
+          rootContext: data.rootContext,
         },
       },
       (err, lrResult) => {

--- a/test/sass-loader-example/webpack.config.js
+++ b/test/sass-loader-example/webpack.config.js
@@ -14,6 +14,9 @@ module.exports = (env) => {
     workerParallelJobs: 2,
     poolTimeout: env.watch ? Infinity : 2000,
   };
+  const sassLoaderOptions = {
+    sourceMap: true,
+  };
   if (+env.threads > 0) {
     threadLoader.warmup(workerPool, ['babel-loader', 'babel-preset-env']);
     threadLoader.warmup(workerPoolSass, ['sass-loader', 'css-loader']);
@@ -47,7 +50,7 @@ module.exports = (env) => {
               options: workerPoolSass,
             },
             'css-loader',
-            'sass-loader',
+            { loader: 'sass-loader', options: sassLoaderOptions },
           ].filter(Boolean),
         },
       ],


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

When used with `sass-loader` and `{ sourceMap: true }`, it fails with the following message:

```
[2] ERROR in ./path/tofoo.scss
[2] Module build failed (from $CWD/node_modules/mini-css-extract-plugin/dist/loader.js):
[2] ModuleBuildError: Module build failed (from $CWD/node_modules/thread-loader/dist/cjs.js):
[2] Thread Loader (Worker 9)
[2] The "path" argument must be of type string. Received undefined
[2]     at PoolWorker.fromErrorObj ($CWD/node_modules/thread-loader/dist/WorkerPool.js:344:12)
[2]     at $CWD/node_modules/thread-loader/dist/WorkerPool.js:217:29
[2]     at validateString (internal/validators.js:124:11)
[2]     at Object.join (path.js:1039:7)
[2]     at getSassOptions ($CWD/node_modules/sass-loader/dist/utils.js:160:37)
[2]     at Object.loader ($CWD/node_modules/sass-loader/dist/index.js:36:49)
[2]     at $CWD/node_modules/webpack/lib/NormalModule.js:316:20
[2]     at $CWD/node_modules/loader-runner/lib/LoaderRunner.js:367:11
[2]     at $CWD/node_modules/loader-runner/lib/LoaderRunner.js:182:20
[2]     at context.callback ($CWD/node_modules/loader-runner/lib/LoaderRunner.js:111:13)
[2]     at Object.callback ($CWD/node_modules/thread-loader/dist/index.js:51:7)
[2]     at done ($CWD/node_modules/neo-async/async.js:8069:18)
[2]     at callback ($CWD/node_modules/thread-loader/dist/WorkerPool.js:183:19)
[2]     at $CWD/node_modules/thread-loader/dist/WorkerPool.js:217:15
[2]     at mapSeries ($CWD/node_modules/neo-async/async.js:3625:14)
[2]     at PoolWorker.onWorkerMessage ($CWD/node_modules/thread-loader/dist/WorkerPool.js:171:34)
[2]     at $CWD/node_modules/thread-loader/dist/WorkerPool.js:144:14
[2]     at Socket.onChunk ($CWD/node_modules/thread-loader/dist/readBuffer.js:40:9)
[2]     at Socket.emit (events.js:315:20)
[2]     at Socket.Readable.read (_stream_readable.js:519:10)
[2]     at Socket.read (net.js:625:39)
[2]     at flow (_stream_readable.js:992:34)
```

This PR fixes the problem by passing `context.rootContext` into workers.

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
