### PR TITLE
fix: parsing circular json

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,12 @@ function pitch() {
       }),
       _compiler: { fsStartTime: this._compiler.fsStartTime },
       _compilation: {
-        outputOptions: this._compilation.outputOptions,
+        outputOptions: {
+          hashSalt: this._compilation.outputOptions.hashSalt,
+          hashFunction: this._compilation.outputOptions.hashFunction,
+          hashDigest: this._compilation.outputOptions.hashDigest,
+          hashDigestLength: this._compilation.outputOptions.hashDigestLength,
+        },
         options: this._compilation.options,
       },
       resourcePath: this.resourcePath,

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,12 @@ function pitch() {
           hashDigest: this._compilation.outputOptions.hashDigest,
           hashDigestLength: this._compilation.outputOptions.hashDigestLength,
         },
-        options: this._compilation.options,
+        options: {
+          devtool:
+            this._compilation &&
+            this._compilation.options &&
+            this._compilation.options.devtool,
+        },
       },
       resourcePath: this.resourcePath,
       resource: this.resourcePath + (this.resourceQuery || ''),

--- a/test/sass-loader-example/webpack.config.js
+++ b/test/sass-loader-example/webpack.config.js
@@ -31,6 +31,7 @@ module.exports = (env) => {
   return {
     mode: 'none',
     context: __dirname,
+    devtool: false,
     entry: ['./index.js'],
     output: {
       path: path.resolve('dist'),


### PR DESCRIPTION
When reading outputoptions, they can become circular. This fixes that and only requires necessary infos.

<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ X] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
